### PR TITLE
Watch route change to close menu

### DIFF
--- a/components/navigation/node/item.vue
+++ b/components/navigation/node/item.vue
@@ -16,7 +16,6 @@
       v-else
       :to="item._path"
       class="block py-1 pl-2 text-sm text-gray-400 transition-colors hover:text-primary-500 dark:hover:text-primary-200"
-      @click="menuState = false"
     >
       {{ item.title }}
     </NuxtLink>
@@ -34,8 +33,6 @@
 
 <script setup lang="ts">
 import { NavItem, TocLink } from '@nuxt/content/dist/runtime/types';
-
-const menuState = useMenuState();
 
 defineProps({
   item: {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -27,9 +27,19 @@
 </template>
 
 <script setup lang="ts">
+const route = ref<string>(useRoute().fullPath);
+
 const { page } = useContent();
 
 const menuState = useMenuState();
+
+watch(
+  route,
+  () => {
+    menuState.value = false;
+  },
+  { deep: true, immediate: true }
+);
 
 watch(menuState, (value) => {
   if (value) {


### PR DESCRIPTION
This PR changes the closing of the menu to route change watch instead of link `@click` because the menu sometimes closed before the route was really changed, resulting in a slight delay between the two actions.