### PR TITLE
Fix: ClientOnly stopped buttons from receiving attributes

### DIFF
--- a/components/navigation/menu-button.vue
+++ b/components/navigation/menu-button.vue
@@ -1,6 +1,7 @@
 <template>
   <ClientOnly>
     <button
+      v-bind="$attrs"
       class="flex h-10 w-10 items-center justify-center rounded text-2xl transition hover:bg-gray-100 dark:hover:bg-gray-800"
       :aria-label="menuState ? 'Close menu' : 'Open menu'"
       @click.prevent="() => (menuState = !menuState)"

--- a/components/navigation/node/item.vue
+++ b/components/navigation/node/item.vue
@@ -16,7 +16,6 @@
       v-else
       :to="item._path"
       class="block py-1 pl-2 text-sm text-gray-400 transition-colors hover:text-primary-500 dark:hover:text-primary-200"
-      @click="menuState = false"
     >
       {{ item.title }}
     </NuxtLink>
@@ -34,8 +33,6 @@
 
 <script setup lang="ts">
 import { NavItem, TocLink } from '@nuxt/content/dist/runtime/types';
-
-const menuState = useMenuState();
 
 defineProps({
   item: {

--- a/components/theme-switch.vue
+++ b/components/theme-switch.vue
@@ -1,6 +1,7 @@
 <template>
   <ClientOnly>
     <button
+      v-bind="$attrs"
       :aria-label="`Switch to ${getNextTheme()} mode`"
       class="rounded p-1 px-3 text-lg text-gray-500 dark:text-gray-300"
       @click="setTheme(colorMode.preference)"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -27,9 +27,19 @@
 </template>
 
 <script setup lang="ts">
+const route = ref<string>(useRoute().fullPath);
+
 const { page } = useContent();
 
 const menuState = useMenuState();
+
+watch(
+  route,
+  () => {
+    menuState.value = false;
+  },
+  { deep: true, immediate: true }
+);
 
 watch(menuState, (value) => {
   if (value) {


### PR DESCRIPTION
Using `<ClientOnly>` resulted in the buttons not receiving the attributes as they're not the root elements of the SFC anymore.