### PR TITLE
Fix article width on smaller contents

### DIFF
--- a/components/layout/article.vue
+++ b/components/layout/article.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="lg:flex lg:gap-8">
-    <article>
+    <article class="flex-grow">
       <span
         v-if="dirName"
         class="mb-2 block font-bold capitalize text-primary"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,10 +9,7 @@
 
         <main class="flex-grow p-8 lg:px-16 lg:py-12">
           <vContainer>
-            <vLayoutArticle
-              v-if="page"
-              class="flex-grow"
-            >
+            <vLayoutArticle v-if="page">
               <slot />
             </vLayoutArticle>
 


### PR DESCRIPTION
The width of articles used up space as the longest content line, making the ToC move to the left on short lines.

![image](https://github.com/Kazuto/wiki-template/assets/25435034/c9113e6f-358c-4b08-946f-976ced3c6758)
